### PR TITLE
Uses gcc -DUSE_X11 in place of spnav.h #include <spnav_config.h>

### DIFF
--- a/configure
+++ b/configure
@@ -91,22 +91,12 @@ if [ "$OPT" = 'yes' ]; then
 fi
 
 if [ "$X11" = 'yes' ]; then
+	echo 'user_cflags = -DUSE_X11' >>Makefile
 	echo 'magellan_obj = spnav_magellan.o' >>Makefile
 	echo 'xlib = -lX11' >>Makefile
 fi
 
 cat "$srcdir/Makefile.in" >>Makefile
-
-# create spnav_config.h
-echo 'creating spnav_config.h ...'
-echo '#ifndef SPNAV_CONFIG_H_' >spnav_config.h
-echo '#define SPNAV_CONFIG_H_' >>spnav_config.h
-echo '' >>spnav_config.h
-if [ "$X11" = 'yes' ]; then
-	echo '#define USE_X11' >>spnav_config.h
-	echo '' >>spnav_config.h
-fi
-echo '#endif	/* SPNAV_CONFIG_H_ */' >>spnav_config.h
 
 #done
 echo ''

--- a/spnav.h
+++ b/spnav.h
@@ -27,8 +27,6 @@ OF SUCH DAMAGE.
 #ifndef SPACENAV_H_
 #define SPACENAV_H_
 
-#include <spnav_config.h>
-
 #ifdef USE_X11
 #include <X11/Xlib.h>
 #endif


### PR DESCRIPTION
Replaces the secondary include file <spnav_config.h> that is generated by ./configure with a compiler pre-processor definition -DUSE_X11.
This is with a view to simplification of "spnav.h" for supporting forward\backward version compatible header \ libraries inter-working with future spacenavd releases.
Change tested by performing two successful builds, one with "./configure --disable-x11", and one with "./configure".