### PR TITLE
[examples/cube] Support spacenavd over Unix

### DIFF
--- a/examples/cube/Makefile
+++ b/examples/cube/Makefile
@@ -1,13 +1,18 @@
-obj = cube.o vmath.o
-bin = cube
-
+BIN = cube
 CC = gcc
 CFLAGS = -pedantic -Wall -g -I../.. -I/usr/local/include
 LDFLAGS = -L../.. -L/usr/local/lib -lX11 -lGL -lGLU -lm -lspnav
+SRC=$(wildcard *.c)
 
-$(bin): $(obj)
-	$(CC) -o $@ $(obj) $(LDFLAGS)
+.PHONY: all
+all: $(BIN)_x11 $(BIN)_unix
+
+$(BIN)_x11: $(SRC)
+	$(CC) -o $@ $^ $(CFLAGS) -DBUILD_X11 $(LDFLAGS)
+
+$(BIN)_unix: $(SRC)
+	$(CC) -o $@ $^ $(CFLAGS) -DBUILD_UNIX $(LDFLAGS)
 
 .PHONY: clean
 clean:
-	rm -f $(obj) $(bin)
+	rm -f $(obj) $(BIN)_unix $(BIN)_x11


### PR DESCRIPTION
## Why?
- Because I cannot get spacenavd to work over x11 on PopOS19.10 running XWayland.

## Fix 
- Fixes #7

## Testing
- [x] spacenavd over Unix
- [ ] spacenavd over x11 (I cannot test this. Please help)

## Code highlight

*Copied this pattern from `examples/simple`* 
```c
#if defined(BUILD_X11)
	if(spnav_x11_open(dpy, win) == -1) {
		fprintf(stderr, "[BUILD_X11] failed to connect to the space navigator daemon\n");
		return 1;
	}
#elif defined(BUILD_UNIX)
	if(spnav_open()==-1) {
		fprintf(stderr, "[BUILD_UNIX] failed to connect to the space navigator daemon\n");
		return 1;
	}
#else
#error Unknown build type!
#endif
```

## Screenshot of this PR running on my machine 🚀
*This was by far the most confortable setting*
<img src="https://user-images.githubusercontent.com/3092618/78460576-34cffb80-76c2-11ea-9d91-a2f58793338d.png" width=500>

