### PR TITLE
Add missing math library as LDFLAG

### DIFF
--- a/examples/simple/Makefile
+++ b/examples/simple/Makefile
@@ -1,6 +1,6 @@
 CC = gcc
 CFLAGS = -pedantic -Wall -g -I../.. -I../../src -I/usr/local/include
-LDFLAGS = -L../.. -L/usr/local/lib -lspnav -lX11
+LDFLAGS = -L../.. -L/usr/local/lib -lspnav -lX11 -lm
 
 .PHONY: all
 all: simple_x11 simple_af_unix


### PR DESCRIPTION
Missing math functions to compile the `simple` example:

```
$ make
gcc -pedantic -Wall -g -I../.. -I../../src -I/usr/local/include -DBUILD_AF_UNIX -o simple_af_unix simple.c -L../.. -L/usr/local/lib -lspnav -lX11
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/12/../../../../lib/libspnav.so: undefined reference to `sincos'
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/12/../../../../lib/libspnav.so: undefined reference to `sqrt'
collect2: error: ld returned 1 exit status
make: *** [Makefile:11: simple_af_unix] Error 1
```
