### PR TITLE
README.md: added troubleshooting to build examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ installing libspnav system-wide, which is the common case
 
 Running `./configure --help` prints available build options.
 
+If you try to build the examples and get a compile error about a missing
+GL header file, you might wanna install `libgl-dev` and `libglu1-mesa-dev`.
 
 License
 -------


### PR DESCRIPTION
Give directions when hitting compile error:
```
thehacker@rhea:/tmp/libspnav/examples/fly$ LC_ALL=C make
gcc -pedantic -Wall -O3 -I../.. -I../../src -I/usr/local/include   -c -o fly.o fly.c
fly.c:14:10: fatal error: GL/glu.h: No such file or directory
   14 | #include <GL/glu.h>
      |          ^~~~~~~~~~
compilation terminated.
make: *** [<builtin>: fly.o] Error 1
```