### PR TITLE
Make CI run once a week

### DIFF
--- a/.github/workflows/build_freebsd.yml
+++ b/.github/workflows/build_freebsd.yml
@@ -4,6 +4,8 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: '0 4 * * 6'  # Every Saturday at 4am
 
 jobs:
   build:

--- a/.github/workflows/build_gnulinux.yml
+++ b/.github/workflows/build_gnulinux.yml
@@ -4,6 +4,8 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: '0 4 * * 6'  # Every Saturday at 4am
 
 jobs:
   build:

--- a/.github/workflows/build_macosx.yml
+++ b/.github/workflows/build_macosx.yml
@@ -4,6 +4,8 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: '0 4 * * 6'  # Every Saturday at 4am
 
 jobs:
   build:


### PR DESCRIPTION
This will make sure that when the ground moves below libspnav's feet, it will take no longer than a week to be alarmed of that breakage. That allows addressing CI issues early and where there is time available and makes sure that spontaneous pull requests have a chance at a green CI at all times.

@jtsiomb what do you think?